### PR TITLE
Filter ODL jobs based on user and process name

### DIFF
--- a/files/upstart.odl.conf
+++ b/files/upstart.odl.conf
@@ -15,6 +15,5 @@ console output
 
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/
 
-exec start-stop-daemon --start --chuid odl --group odl --exec /opt/opendaylight/bin/start
-
+exec start-stop-daemon --start --chuid odl:odl -u odl -n java --startas /opt/opendaylight/bin/karaf --
 

--- a/files/upstart.odl.conf
+++ b/files/upstart.odl.conf
@@ -5,9 +5,9 @@
 description     "OpenDaylight SDN Controller"
 
 # Make sure we start before an interface receives traffic
-start on (starting network-interface
-          or starting network-manager
-          or starting networking)
+start on (started network-interface
+          or started network-manager
+          or started networking)
 
 stop on runlevel [!023456]
 
@@ -15,5 +15,5 @@ console output
 
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64/
 
-exec start-stop-daemon --start --chuid odl:odl -u odl -n java --startas /opt/opendaylight/bin/karaf --
+exec start-stop-daemon --start --chuid odl:odl -u odl -n java --startas /opt/opendaylight/bin/karaf -- server
 


### PR DESCRIPTION
On my Ubuntu 14.04 based system the previous script was causing
multiple instances of ODL to spawn due to the fact that PID tracking
was searching for `karaf` process, whereas the the karaf process
spawned a `java` instance. Hence Upstart tracked a wrong PID and
assumed that ODL job is always stopped. That also caused inability to
stop the service, because PID was incorrect, so upstart was sending
SIGTERM to a wrong process.
With this change, upstart searches for a `java` process belonging to
user `odl` in order to determine the PID.