### PR TITLE
Ensure every puppet run does not unzip the odl 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -95,6 +95,7 @@ class opendaylight::install {
       # This discards top-level dir of extracted tarball
       # Required to get proper /opt/opendaylight/ path
       strip_components => 1,
+      root_dir         => '.',
       # Default timeout is 120s, which may not be enough. See Issue #53:
       # https://github.com/dfarrell07/puppet-opendaylight/issues/53
       timeout          => 600,


### PR DESCRIPTION
Every time puppet runs, the odl zip was getting downloaded unzipping and restarting services. To ensure this doesnt happen, we need to add a root_dir in the archive provider .

This will ensure that multiple puppet runs will not cause any service restarts