### PR TITLE
Adds security group mode configuration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -410,6 +410,14 @@ Default: `'https://github.com/dfarrell07/opendaylight-systemd/archive/master/ope
 Valid options: A valid URL to an ODL systemd .service file (archived in a
 tarball) as a string.
 
+##### `security_group_mode`
+
+Specifies the mode to use for security groups.
+
+Default: `stateful`
+
+Valid options: `transparent`, `learn`, `statless`
+
 ## Limitations
 
 * Tested on Fedora 22, 23, CentOS 7 and Ubuntu 14.04.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,21 +29,24 @@
 #   Array of IPs for each node in the HA cluster.
 # [*ha_node_index*]
 #   Index of ha_node_ips for this node.
+# [*security_group_mode*]
+#   Sets the mode to use for security groups (stateful, learn, stateless, transparent)
 #
 class opendaylight (
-  $default_features = $::opendaylight::params::default_features,
-  $extra_features = $::opendaylight::params::extra_features,
-  $odl_rest_port = $::opendaylight::params::odl_rest_port,
-  $odl_bind_ip = $::opendaylight::params::odl_bind_ip,
-  $install_method = $::opendaylight::params::install_method,
-  $rpm_repo = $::opendaylight::params::rpm_repo,
-  $tarball_url = $::opendaylight::params::tarball_url,
-  $unitfile_url = $::opendaylight::params::unitfile_url,
-  $enable_l3 = $::opendaylight::params::enable_l3,
-  $log_levels = $::opendaylight::params::log_levels,
-  $enable_ha = $::opendaylight::params::enable_ha,
-  $ha_node_ips = $::opendaylight::params::ha_node_ips,
-  $ha_node_index = $::opendaylight::params::ha_node_index,
+  $default_features    = $::opendaylight::params::default_features,
+  $extra_features      = $::opendaylight::params::extra_features,
+  $odl_rest_port       = $::opendaylight::params::odl_rest_port,
+  $odl_bind_ip         = $::opendaylight::params::odl_bind_ip,
+  $install_method      = $::opendaylight::params::install_method,
+  $rpm_repo            = $::opendaylight::params::rpm_repo,
+  $tarball_url         = $::opendaylight::params::tarball_url,
+  $unitfile_url        = $::opendaylight::params::unitfile_url,
+  $enable_l3           = $::opendaylight::params::enable_l3,
+  $log_levels          = $::opendaylight::params::log_levels,
+  $enable_ha           = $::opendaylight::params::enable_ha,
+  $ha_node_ips         = $::opendaylight::params::ha_node_ips,
+  $ha_node_index       = $::opendaylight::params::ha_node_index,
+  $security_group_mode = $::opendaylight::params::security_group_mode,
 ) inherits ::opendaylight::params {
 
   # Validate OS family
@@ -63,6 +66,9 @@ class opendaylight (
       if $::operatingsystemmajrelease != '7' {
         # RHEL/CentOS versions < 7 not supported as they lack systemd
         fail("Unsupported OS: ${::operatingsystem} ${::operatingsystemmajrelease}")
+      } elsif (versioncmp($::operatingsystemrelease, '7.3') < 0) {
+        # Versions < 7.3 do not support stateful security groups
+        $stateful_unsupported = true
       }
     }
     fedora: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,5 @@ class opendaylight::params {
   $enable_ha = false
   $ha_node_ips = []
   $ha_node_index = ''
+  $security_group_mode = 'stateful'
 }

--- a/spec/classes/opendaylight_spec.rb
+++ b/spec/classes/opendaylight_spec.rb
@@ -699,4 +699,78 @@ describe 'opendaylight' do
       end
     end
   end
+  # Security Group Tests
+  describe 'security group tests' do
+    # Non-OS-type tests assume CentOS 7
+    #   See issue #43 for reasoning:
+    #   https://github.com/dfarrell07/puppet-opendaylight/issues/43#issue-57343159
+    osfamily = 'RedHat'
+    operatingsystem = 'CentOS'
+    operatingsystemmajrelease = '7'
+    context 'using supported stateful' do
+      let(:facts) {{
+        :osfamily => osfamily,
+        :operatingsystem => operatingsystem,
+        :operatingsystemmajrelease => operatingsystemmajrelease,
+        :operatingsystemrelease => '7.3',
+      }}
+
+      let(:params) {{
+        :security_group_mode => 'stateful',
+        :extra_features      => ['odl-netvirt-openstack'],
+      }}
+
+      # Run shared tests applicable to all supported OSs
+      # Note that this function is defined in spec_helper
+      generic_tests
+
+      # Run test that specialize in checking security groups
+      # Note that this function is defined in spec_helper
+      enable_sg_tests(security_group_mode: 'stateful', osrelease: '7.3')
+    end
+
+    context 'using unsupported stateful' do
+      let(:facts) {{
+        :osfamily => osfamily,
+        :operatingsystem => operatingsystem,
+        :operatingsystemmajrelease => operatingsystemmajrelease,
+        :operatingsystemrelease => '7.2.1511',
+      }}
+
+      let(:params) {{
+        :security_group_mode => 'stateful',
+        :extra_features      => ['odl-netvirt-openstack'],
+      }}
+
+      # Run shared tests applicable to all supported OSs
+      # Note that this function is defined in spec_helper
+      generic_tests
+
+      # Run test that specialize in checking security groups
+      # Note that this function is defined in spec_helper
+      enable_sg_tests(security_group_mode: 'stateful', osrelease: '7.2.1511')
+    end
+
+    context 'using transparent with unsupported stateful' do
+      let(:facts) {{
+        :osfamily => osfamily,
+        :operatingsystem => operatingsystem,
+        :operatingsystemmajrelease => operatingsystemmajrelease,
+        :operatingsystemrelease => '7.2.1511',
+      }}
+
+      let(:params) {{
+        :security_group_mode => 'transparent',
+        :extra_features      => ['odl-netvirt-openstack'],
+      }}
+
+      # Run shared tests applicable to all supported OSs
+      # Note that this function is defined in spec_helper
+      generic_tests
+
+      # Run test that specialize in checking security groups
+      # Note that this function is defined in spec_helper
+      enable_sg_tests(security_group_mode: 'transparent', osrelease: '7.2.1511')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -410,3 +410,36 @@ def unsupported_os_tests(options = {})
   it { expect { should contain_service('opendaylight') }.to raise_error(Puppet::Error, /#{expected_msg}/) }
   it { expect { should contain_file('org.apache.karaf.features.cfg') }.to raise_error(Puppet::Error, /#{expected_msg}/) }
 end
+
+# Shared tests that specialize in testing enabling L3 via ODL OVSDB
+def enable_sg_tests(options = {})
+  # Extract params
+  # NB: This default value should be the same as one in opendaylight::params
+  # TODO: Remove this possible source of bugs^^
+  sg_mode = options.fetch(:security_group_mode, 'stateful')
+  os_release = options.fetch(:osrelease)
+
+  if !os_release.include? '7.3' and ['stateful'].include? sg_mode
+    # Confirm sg_mode becomes learn
+    it {
+      should contain_file('netvirt-aclservice-config.xml').with(
+        'ensure'      => 'file',
+        'path'        => '/opt/opendaylight/etc/opendaylight/datastore/initial/config/netvirt-aclservice-config.xml',
+        'owner'   => 'odl',
+        'group'   => 'odl',
+        'content'     => /learn/
+      )
+    }
+  else
+    # Confirm other sg_mode is passed correctly
+    it {
+      should contain_file('netvirt-aclservice-config.xml').with(
+        'ensure'      => 'file',
+        'path'        => '/opt/opendaylight/etc/opendaylight/datastore/initial/config/netvirt-aclservice-config.xml',
+        'owner'   => 'odl',
+        'group'   => 'odl',
+        'content'     => /#{sg_mode}/
+      )
+    }
+  end
+end

--- a/templates/netvirt-aclservice-config.xml.erb
+++ b/templates/netvirt-aclservice-config.xml.erb
@@ -1,0 +1,3 @@
+<aclservice-config xmlns="urn:opendaylight:netvirt:aclservice-config">
+  <security-group-mode><%= scope.lookupvar('opendaylight::config::sg_mode') %></security-group-mode>
+</aclservice-config>


### PR DESCRIPTION
Security grouop mode defaults to stateful in Boron release. Red Hat
based systems less than 7.3 release are unable to use stateful.  This
patch detects those OS types and fallsback to 'learn' mode.  The mode is
also configurable as a new param to the opendaylight class.

Signed-off-by: Tim Rozet <tdrozet@gmail.com>