### PR TITLE
Fixes detecting security group mode based on OS version

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -82,13 +82,9 @@ class opendaylight::config {
   # Requires at least CentOS 7.3 for RHEL/CentOS systems
   if ('odl-netvirt-openstack' in $opendaylight::features) {
     if $opendaylight::security_group_mode == 'stateful' {
-      if defined('$opendaylight::stateful_unsupported') {
-        if $opendaylight::stateful_unsupported {
+      if defined('$opendaylight::stateful_unsupported') and $opendaylight::stateful_unsupported {
           warning("Stateful is unsupported in ${::operatingsystemrelease} setting to 'learn'")
           $sg_mode = 'learn'
-        } else {
-            $sg_mode = 'learn'
-        }
       } else {
         $sg_mode = 'stateful'
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@ class opendaylight (
       if $::operatingsystemmajrelease != '7' {
         # RHEL/CentOS versions < 7 not supported as they lack systemd
         fail("Unsupported OS: ${::operatingsystem} ${::operatingsystemmajrelease}")
-      } elsif defined('::operatingsystemrelease') {
+      } elsif defined('$::operatingsystemrelease') {
           if (versioncmp($::operatingsystemrelease, '7.3') < 0) {
             # Versions < 7.3 do not support stateful security groups
             $stateful_unsupported = true

--- a/spec/classes/opendaylight_spec.rb
+++ b/spec/classes/opendaylight_spec.rb
@@ -730,7 +730,7 @@ describe 'opendaylight' do
 
       # Run test that specialize in checking security groups
       # Note that this function is defined in spec_helper
-      enable_sg_tests(security_group_mode: 'stateful', osrelease: '7.3')
+      enable_sg_tests('stateful', '7.3')
     end
 
     context 'using unsupported stateful' do
@@ -752,7 +752,7 @@ describe 'opendaylight' do
 
       # Run test that specialize in checking security groups
       # Note that this function is defined in spec_helper
-      enable_sg_tests(security_group_mode: 'stateful', osrelease: '7.3')
+      enable_sg_tests('stateful', '7.2.1511')
     end
 
     context 'using transparent with unsupported stateful' do
@@ -774,7 +774,7 @@ describe 'opendaylight' do
 
       # Run test that specialize in checking security groups
       # Note that this function is defined in spec_helper
-      enable_sg_tests(security_group_mode: 'transparent', osrelease: '7.2.1511')
+      enable_sg_tests('transparent', '7.2.1511')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -411,15 +411,13 @@ def unsupported_os_tests(options = {})
   it { expect { should contain_file('org.apache.karaf.features.cfg') }.to raise_error(Puppet::Error, /#{expected_msg}/) }
 end
 
-# Shared tests that specialize in testing enabling L3 via ODL OVSDB
-def enable_sg_tests(options = {})
+# Shared tests that specialize in testing security group mode
+def enable_sg_tests(sg_mode='stateful', os_release)
   # Extract params
   # NB: This default value should be the same as one in opendaylight::params
   # TODO: Remove this possible source of bugs^^
-  sg_mode = options.fetch(:security_group_mode, 'stateful')
-  os_release = options.fetch(:osrelease)
 
-  if !os_release.include? '7.3' and ['stateful'].include? sg_mode
+  if os_release != '7.3' and sg_mode == 'stateful'
     # Confirm sg_mode becomes learn
     it {
       should contain_file('netvirt-aclservice-config.xml').with(


### PR DESCRIPTION
Issue with using the defined() function with variables.  Variables need
to be preceeded by '$'.  However, this does not seem to work with system
facts.  Easiest way to solve this is to just compare to 'undef', which
resolves to false if undefined.

closes #122

Signed-off-by: Tim Rozet <tdrozet@gmail.com>