### PR TITLE
Add vpp_routing_node parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -379,6 +379,15 @@ Default: `stateful`
 
 Valid options: `transparent`, `learn`, `statless`
 
+##### `vpp_routing_node`
+
+Specifies the routing node for VPP deployment. A non-empty string will create config file
+org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg with routing-node set.
+
+Default: `''`
+
+Valid options: A valid host name to a VPP node handling routing.
+
 ## Limitations
 
 - Tested on Fedora 22, 23, CentOS 7 and Ubuntu 14.04.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,4 +93,19 @@ class opendaylight::config {
       content => template('opendaylight/netvirt-aclservice-config.xml.erb'),
     }
   }
+
+  #configure VPP routing node
+  if ! empty($::opendaylight::vpp_routing_node) {
+    file { 'org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg':
+      ensure => file,
+      path   => '/opt/opendaylight/etc/org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg',
+      owner  => 'odl',
+      group  => 'odl',
+    }
+    file_line { 'routing-node':
+      path  => '/opt/opendaylight/etc/org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg',
+      line  => "routing-node=${::opendaylight::vpp_routing_node}",
+      match => '^routing-node=.*$',
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,8 @@
 #   Index of ha_node_ips for this node.
 # [*security_group_mode*]
 #   Sets the mode to use for security groups (stateful, learn, stateless, transparent)
+# [*vpp_routing_node*]
+#   Sets routing node for VPP deployments. Defaults to ''.
 #
 class opendaylight (
   $default_features    = $::opendaylight::params::default_features,
@@ -49,6 +51,7 @@ class opendaylight (
   $ha_node_ips         = $::opendaylight::params::ha_node_ips,
   $ha_node_index       = $::opendaylight::params::ha_node_index,
   $security_group_mode = $::opendaylight::params::security_group_mode,
+  $vpp_routing_node    = $::opendaylight::params::vpp_routing_node,
 ) inherits ::opendaylight::params {
 
   # Validate OS family

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,5 @@ class opendaylight::params {
   $ha_node_ips = []
   $ha_node_index = 0
   $security_group_mode = 'stateful'
+  $vpp_routing_node = ''
 }

--- a/spec/classes/opendaylight_spec.rb
+++ b/spec/classes/opendaylight_spec.rb
@@ -741,4 +741,52 @@ describe 'opendaylight' do
       enable_sg_tests('transparent', '7.2.1511')
     end
   end
+
+  # VPP routing node config tests
+  describe 'VPP routing node tests' do
+    # Non-OS-type tests assume CentOS 7
+    #   See issue #43 for reasoning:
+    #   https://github.com/dfarrell07/puppet-opendaylight/issues/43#issue-57343159
+    osfamily = 'RedHat'
+    operatingsystem = 'CentOS'
+    operatingsystemmajrelease = '7'
+    context 'using default - no routing node' do
+      let(:facts) {{
+        :osfamily => osfamily,
+        :operatingsystem => operatingsystem,
+        :operatingsystemmajrelease => operatingsystemmajrelease,
+      }}
+
+      let(:params) {{ }}
+
+      # Run shared tests applicable to all supported OSs
+      # Note that this function is defined in spec_helper
+      generic_tests
+
+      # Run test that specialize in checking routing-node config
+      # Note that this function is defined in spec_helper
+      vpp_routing_node_tests
+    end
+
+    context 'using node name for routing node' do
+      let(:facts) {{
+        :osfamily => osfamily,
+        :operatingsystem => operatingsystem,
+        :operatingsystemmajrelease => operatingsystemmajrelease,
+      }}
+
+      let(:params) {{
+        :vpp_routing_node => 'test-node-1',
+      }}
+
+      # Run shared tests applicable to all supported OSs
+      # Note that this function is defined in spec_helper
+      generic_tests
+
+      # Run test that specialize in checking routing-node config
+      # Note that this function is defined in spec_helper
+      vpp_routing_node_tests(routing_node: 'test-node-1')
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -439,3 +439,35 @@ def enable_sg_tests(sg_mode='stateful', os_release)
     }
   end
 end
+
+# Shared tests that specialize in testing VPP routing node config
+def vpp_routing_node_tests(options = {})
+  # Extract params
+  # NB: This default list should be the same as the one in opendaylight::params
+  # TODO: Remove this possible source of bugs^^
+  routing_node = options.fetch(:routing_node, '')
+
+  if routing_node.empty?
+    it { should_not contain_file('org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg') }
+    it { should_not contain_file_line('routing-node') }
+  else
+    # Confirm properties of Karaf config file
+    # NB: These hashes don't work with Ruby 1.8.7, but we
+    #   don't support 1.8.7 so that's okay. See issue #36.
+    it {
+      should contain_file('org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg').with(
+        'ensure'      => 'file',
+        'path'        => '/opt/opendaylight/etc/org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg',
+        'owner'   => 'odl',
+        'group'   => 'odl',
+      )
+    }
+    it {
+      should contain_file_line('routing-node').with(
+        'path'  => '/opt/opendaylight/etc/org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg',
+        'line'  => "routing-node=#{routing_node}",
+        'match' => '^routing-node=.*$',
+      )
+    }
+  end
+end


### PR DESCRIPTION
This patch add vpp_routing_node parameter. It specifies the node that
should be used for routing in VPP deployments. The Opendaylight patch
introducing this parameter is at https://git.opendaylight.org/gerrit/#/c/51250

Signed-off-by: Feng Pan <fpan@redhat.com>