### PR TITLE
Adds ability to pass Java options to ODL startup

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -377,7 +377,7 @@ Specifies the mode to use for security groups.
 
 Default: `stateful`
 
-Valid options: `transparent`, `learn`, `statless`
+Valid options: `transparent`, `learn`, `stateless`
 
 ##### `vpp_routing_node`
 
@@ -387,6 +387,14 @@ org.opendaylight.groupbasedpolicy.neutron.vpp.mapper.cfg with routing-node set.
 Default: `''`
 
 Valid options: A valid host name to a VPP node handling routing.
+
+##### `java_opts`
+
+Specifies the Java options to run ODL with as a string.
+
+Default: `'-Djava.net.preferIPv4Stack=true'`
+
+Valid options: A string of valid Java options.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,8 @@
 #   Sets the mode to use for security groups (stateful, learn, stateless, transparent)
 # [*vpp_routing_node*]
 #   Sets routing node for VPP deployments. Defaults to ''.
+# [*java_opts*]
+#   Sets Java options for ODL in a string format. Defaults to '-Djava.net.preferIPv4Stack=true'.
 #
 class opendaylight (
   $default_features    = $::opendaylight::params::default_features,
@@ -52,6 +54,7 @@ class opendaylight (
   $ha_node_index       = $::opendaylight::params::ha_node_index,
   $security_group_mode = $::opendaylight::params::security_group_mode,
   $vpp_routing_node    = $::opendaylight::params::vpp_routing_node,
+  $java_opts           = $::opendaylight::params::java_opts,
 ) inherits ::opendaylight::params {
 
   # Validate OS family

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,11 +29,12 @@ class opendaylight::install {
       require => Yumrepo[$opendaylight::rpm_repo],
     }
     ->
-    # Configure the systemd file to force ipv4 binds (instead of ipv6)
-    file_line { 'odl_start_ipv4':
+    # Configure the systemd file with Java options
+    file_line { 'java_options_systemd':
       ensure => present,
       path   => '/usr/lib/systemd/system/opendaylight.service',
-      line   => 'Environment=_JAVA_OPTIONS=\'-Djava.net.preferIPv4Stack=true\'',
+      line   => "Environment=_JAVA_OPTIONS=\'${opendaylight::java_opts}\'",
+      match  => '^Environment.*',
       after  => 'ExecStart=/opt/opendaylight/bin/start',
     }
     ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class opendaylight::params {
   $ha_node_index = 0
   $security_group_mode = 'stateful'
   $vpp_routing_node = ''
+  $java_opts = '-Djava.net.preferIPv4Stack=true'
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -347,6 +347,7 @@ end
 def rpm_install_tests(options = {})
   # Extract params
   rpm_repo = options.fetch(:rpm_repo, 'opendaylight-5-testing')
+  java_opts = options.fetch(:java_opts, '-Djava.net.preferIPv4Stack=true')
 
   # Default to CentOS 7 Yum repo URL
 
@@ -376,10 +377,10 @@ def rpm_install_tests(options = {})
   }
 
   it {
-    should contain_file_line('odl_start_ipv4').with(
+    should contain_file_line('java_options_systemd').with(
       'ensure' => 'present',
       'path' => '/usr/lib/systemd/system/opendaylight.service',
-      'line' => 'Environment=_JAVA_OPTIONS=\'-Djava.net.preferIPv4Stack=true\'',
+      'line' => "Environment=_JAVA_OPTIONS=\'#{java_opts}\'",
       'after' => 'ExecStart=/opt/opendaylight/bin/start',
     )
   }


### PR DESCRIPTION
Previously we always set the Java options to a single value which will
only run Java with ipv4 stack.  There is a requirement to be able to set
other parameters like heap seize or enable garbage collection.  This
change exposes a parameter where many Java options can be set via a
string.

Signed-off-by: Tim Rozet <tdrozet@gmail.com>