### PR TITLE
Fix idempotency around systemd restart

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,10 +36,11 @@ class opendaylight::install {
       match  => '^Environment.*',
       after  => 'ExecStart=/opt/opendaylight/bin/start',
     }
-    ->
+    ~>
     exec {'reload_systemd_units':
-      command => 'systemctl daemon-reload',
-      path    => '/bin'
+      command     => 'systemctl daemon-reload',
+      path        => '/bin',
+      refreshonly => true,
     }
   }
 


### PR DESCRIPTION
Switch the exec to reload the systemd daemon to only occur when the
puppet module updates the systemd unit file.