### PR TITLE
Allow for disabling repository configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem "metadata-json-lint"
   gem "travis"
   gem "travis-lint"
+  gem "rspec-puppet-facts", :require => false
 end
 
 group :local_only do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,10 @@
 #   Sets routing node for VPP deployments. Defaults to ''.
 # [*java_opts*]
 #   Sets Java options for ODL in a string format. Defaults to '-Djava.net.preferIPv4Stack=true'.
+# [*manage_repositories*]
+#   (Boolean) Should this module manage the apt or yum repositories for the
+#   package installation.
+#   Defaults to true
 #
 class opendaylight (
   $default_features    = $::opendaylight::params::default_features,
@@ -48,6 +52,7 @@ class opendaylight (
   $security_group_mode = $::opendaylight::params::security_group_mode,
   $vpp_routing_node    = $::opendaylight::params::vpp_routing_node,
   $java_opts           = $::opendaylight::params::java_opts,
+  $manage_repositories = $::opendaylight::params::manage_repositories,
 ) inherits ::opendaylight::params {
 
   # Validate OS family

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,59 +6,29 @@
 # system state should be functionally equivalent.
 #
 class opendaylight::install {
-  if $::osfamily == 'RedHat' {
-    # Add OpenDaylight's Yum repository
-    yumrepo { $opendaylight::rpm_repo:
-      # 'ensure' isn't supported with Puppet <3.5
-      # Seems to default to present, but docs don't say
-      # https://docs.puppetlabs.com/references/3.4.0/type.html#yumrepo
-      # https://docs.puppetlabs.com/references/3.5.0/type.html#yumrepo
-      baseurl  => "http://cbs.centos.org/repos/nfv7-${opendaylight::rpm_repo}/\$basearch/os/",
-      descr    => 'OpenDaylight SDN Controller',
-      enabled  => 1,
-      # NB: RPM signing is an active TODO, but is not done. We will enable
-      #     this gpgcheck once the RPM supports it.
-      gpgcheck => 0,
-      before   => Package['opendaylight'],
-    }
 
-    # Install the OpenDaylight RPM
-    package { 'opendaylight':
-      ensure  => present,
-      require => Yumrepo[$opendaylight::rpm_repo],
-    }
-    ->
+  if $::opendaylight::manage_repositories {
+    require ::opendaylight::repos
+  }
+
+  package { 'opendaylight':
+    ensure  => present,
+  }
+
+  if $::osfamily == 'RedHat' {
     # Configure the systemd file with Java options
     file_line { 'java_options_systemd':
-      ensure => present,
-      path   => '/usr/lib/systemd/system/opendaylight.service',
-      line   => "Environment=_JAVA_OPTIONS=\'${opendaylight::java_opts}\'",
-      match  => '^Environment.*',
-      after  => 'ExecStart=/opt/opendaylight/bin/start',
+      ensure  => present,
+      path    => '/usr/lib/systemd/system/opendaylight.service',
+      line    => "Environment=_JAVA_OPTIONS=\'${::opendaylight::java_opts}\'",
+      match   => '^Environment.*',
+      after   => 'ExecStart=/opt/opendaylight/bin/start',
+      require => Package['opendaylight'],
     }
     ->
     exec {'reload_systemd_units':
       command => 'systemctl daemon-reload',
       path    => '/bin'
     }
-  }
-
-  elsif $::osfamily == 'Debian'{
-
-    include apt
-
-    # Add ODL ppa repository
-    apt::ppa{ $opendaylight::deb_repo: }
-
-    # Install Opendaylight .deb pkg
-    package { 'opendaylight':
-      ensure  => present,
-      require => Apt::Ppa[$opendaylight::deb_repo],
-    }
-
-    Apt::Ppa[$opendaylight::deb_repo] -> Package['opendaylight']
-  }
-  else {
-    fail("Unknown operating system method: ${::osfamily}")
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,5 @@ class opendaylight::params {
   $security_group_mode = 'stateful'
   $vpp_routing_node = ''
   $java_opts = '-Djava.net.preferIPv4Stack=true'
+  $manage_repositories = true
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,0 +1,52 @@
+# == Class: opendaylight::repos
+#
+# Manages the installation of the OpenDaylight repositories for RedHat and
+# Debian
+#
+# === Parameters
+#
+# [*deb_repo*]
+#  The name of the debppa repo to configure. Ignored if on a RHEL based system.
+#  Defaults to $::opendaylight::deb_repo
+#
+# [*rpm_repo*]
+#  The name of the rpm repo to configure. Ignored if on a Debian based system
+#  Defaults to $::opendaylight::rpm_repo
+#
+# [*rpm_repo_enabled*]
+#  Flag to indicate if the the rpm repo should be enabled or disabled.
+#  Defualts to 1.
+#
+# [*rpm_repo_gpgcheck*]
+#  Flag to indicate if the rpm repo should be configured with gpgcheck.
+#  Defaults to 0.
+#
+class opendaylight::repos (
+  $deb_repo          = $::opendaylight::deb_repo,
+  $rpm_repo          = $::opendaylight::rpm_repo,
+  $rpm_repo_enabled  = 1,
+  $rpm_repo_gpgcheck = 0,
+) inherits ::opendaylight {
+  if $::osfamily == 'RedHat' {
+    # Add OpenDaylight's Yum repository
+    yumrepo { $rpm_repo:
+      # 'ensure' isn't supported with Puppet <3.5
+      # Seems to default to present, but docs don't say
+      # https://docs.puppetlabs.com/references/3.4.0/type.html#yumrepo
+      # https://docs.puppetlabs.com/references/3.5.0/type.html#yumrepo
+      baseurl  => "http://cbs.centos.org/repos/nfv7-${rpm_repo}/\$basearch/os/",
+      descr    => 'OpenDaylight SDN Controller',
+      enabled  => $rpm_repo_enabled,
+      # NB: RPM signing is an active TODO, but is not done. We will enable
+      #     this gpgcheck once the RPM supports it.
+      gpgcheck => $rpm_repo_gpgcheck,
+    }
+  } elsif ($::osfamily == 'Debian') {
+    include ::apt
+
+    # Add ODL ppa repository
+    apt::ppa{ $deb_repo: }
+  } else {
+    fail("Unknown operating system method: ${::osfamily}")
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
         {
             "operatingsystem": "Ubuntu",
             "operatingsystemrelease": [
-                "14.04"
+                "16.04"
             ]
         }
     ],

--- a/spec/classes/opendaylight_repos_spec.rb
+++ b/spec/classes/opendaylight_repos_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'opendaylight::repos' do
+  shared_examples_for "opendaylight::repos on Debian" do
+    context "with defaults" do
+      it { should contain_class('opendaylight::repos') }
+      it { should contain_class('apt') }
+      it { should contain_apt__ppa('ppa:odl-team/boron') }
+    end
+
+    context "with custom deb_repo" do
+      let(:params) do
+        { :deb_repo => 'ppa:foo/testing' }
+      end
+
+      it { should contain_apt__ppa('ppa:foo/testing') }
+    end
+  end
+  shared_examples_for "opendaylight::repos on RedHat" do
+    context "with defaults" do
+      it { should contain_class('opendaylight::repos') }
+      it {
+        should contain_yumrepo('opendaylight-5-testing').with(
+          :baseurl  => 'http://cbs.centos.org/repos/nfv7-opendaylight-5-testing/$basearch/os/',
+          :enabled  => 1,
+          :gpgcheck => 0,
+        )
+      }
+    end
+
+    context "with custom rpm repo options" do
+      let(:params) do
+        {
+          :rpm_repo => 'testing',
+          :rpm_repo_enabled => 0,
+          :rpm_repo_gpgcheck => 1,
+        }
+      end
+      it {
+        should contain_yumrepo('testing').with(
+          :baseurl  => 'http://cbs.centos.org/repos/nfv7-testing/$basearch/os/',
+          :enabled  => 0,
+          :gpgcheck => 1,
+        )
+      }
+
+    end
+  end
+
+  describe "on unsupported os" do
+    context "when on Solaris" do
+      let(:facts) do
+        {:osfamily => 'Solaris', :operatingsystem => 'Solaris'}
+      end
+
+
+      it 'should fail' do
+        expect { is_expected.to raise_error(Puppet::Error) }
+      end
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts
+      end
+
+      it_behaves_like "opendaylight::repos on #{facts[:osfamily]}"
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 # Customize filters to ignore 3rd-party code
 # If the coverage report shows not-our-code results, add it here


### PR DESCRIPTION
This change moves the repository configuration to it's own class so it
can be included externally and excludeded if necessary. As part of this
change, the inclusion of rspec-puppet-facts was done to simplify testing
support os configurations.
See https://github.com/mcanevet/rspec-puppet-facts for details on how to
work with rspec-puppet-facts. By default it uses the metadata.json for
the supported operating systems. Since 14.04 is not a supported
configuration based on the failure in ::opendaylight, this has also been
updated to reference 16.04 as a supported version.